### PR TITLE
Fixed link protocol

### DIFF
--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,4 +1,4 @@
-<a id="logo" href="http://www.zapic.com">
+<a id="logo" href="https://www.zapic.com">
     <svg id="svg2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://www.w3.org/2000/svg" width="100"
         height="100%" version="1.1" xmlns:cc="http://creativecommons.org/ns#" xmlns:dc="http://purl.org/dc/elements/1.1/"
         viewBox="0 0 1300 1300">


### PR DESCRIPTION
We want all links to explicitly have the "https://" protocol. This minimizes redirects that might cause tools like Google Analytics and Mautic to lose referrer information.